### PR TITLE
Fix for index.js require and cleanup of unused options in lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 
-module.exports = require('./lib/fs-traverse');
+module.exports = require('./lib/mongoose-stamps.js');
+

--- a/lib/mongoose-stamps.js
+++ b/lib/mongoose-stamps.js
@@ -1,7 +1,3 @@
-// Define some sane default options
-var defaultOptions = {
-
-};
 
 /**
  * `Timestamps` Plugin for Mongoose.
@@ -11,8 +7,6 @@ var defaultOptions = {
  * @api public
  */
 function timestampsPlugin(schema, options) {
-  // Extend the default options
-  options = _.defaults(options || {}, defaultOptions);
 
   // Add the fields to the schema
   schema.add({
@@ -46,3 +40,4 @@ function timestampsPlugin(schema, options) {
  * Expose `Timestamps` Plugin Library.
  */
 module.exports = timestampsPlugin;
+


### PR DESCRIPTION
Thanks for the super-useful Mongoose plugin!

It didn't work for me out of the box; submitted is a fix to the `index.js` file `require` that got it working for me.

In addition, some minor cleanup of unused option variables in the plugin library.
